### PR TITLE
Add support for metadata

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,23 +22,23 @@ dockers:
     dockerfile: Dockerfile
     build_flag_templates:
       - "--platform=linux/amd64"
-  - image_templates:
-      - "ghcr.io/airfocusio/{{ .ProjectName }}:{{ .Version }}-arm64v8"
-      - "ghcr.io/airfocusio/{{ .ProjectName }}:latest-arm64v8"
-    use: buildx
-    goarch: arm64
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
+  # - image_templates:
+  #     - "ghcr.io/airfocusio/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+  #     - "ghcr.io/airfocusio/{{ .ProjectName }}:latest-arm64v8"
+  #   use: buildx
+  #   goarch: arm64
+  #   dockerfile: Dockerfile
+  #   build_flag_templates:
+  #     - "--platform=linux/arm64/v8"
 docker_manifests:
   - name_template: ghcr.io/airfocusio/{{ .ProjectName }}:{{ .Version }}
     image_templates:
       - ghcr.io/airfocusio/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/airfocusio/{{ .ProjectName }}:{{ .Version }}-arm64v8
+      # - ghcr.io/airfocusio/{{ .ProjectName }}:{{ .Version }}-arm64v8
   - name_template: ghcr.io/airfocusio/{{ .ProjectName }}:latest
     image_templates:
       - ghcr.io/airfocusio/{{ .ProjectName }}:latest-amd64
-      - ghcr.io/airfocusio/{{ .ProjectName }}:latest-arm64v8
+      # - ghcr.io/airfocusio/{{ .ProjectName }}:latest-arm64v8
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:latest as certs
+FROM alpine:3.16.0 as certs
 RUN apk add --update --no-cache ca-certificates
 
-FROM busybox:latest
+FROM busybox:1.34.1
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/bin/git-ops-update"]
 COPY git-ops-update /bin/git-ops-update

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,9 @@ require (
 require (
 	github.com/fatih/color v1.13.0
 	github.com/go-git/go-billy/v5 v5.3.1
+	github.com/iancoleman/strcase v0.2.0
 	github.com/xanzy/go-gitlab v0.68.0
+	golang.org/x/text v0.3.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh
 github.com/heroku/docker-registry-client v0.0.0-20211012143308-9463674c8930 h1:mNL9ktJqBuzPTV/QP/fKd4y1uOFvfiv6zhe0G7lg9OA=
 github.com/heroku/docker-registry-client v0.0.0-20211012143308-9463674c8930/go.mod h1:Yho0S7KhsnHQRCC5lDraYF1SsLMeWtf/tKdufKu3TJA=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/internal/change.go
+++ b/internal/change.go
@@ -96,7 +96,13 @@ func (cs Changes) Message() string {
 		}
 		sort.Strings(metadataKeys)
 		for _, k := range metadataKeys {
-			lines = append(lines, "    * "+k+": "+c.Metadata[k])
+			value := c.Metadata[k]
+			valueLines := strings.Split(value, "\n")
+			for i := 1; i < len(valueLines); i++ {
+				valueLines[i] = "        " + valueLines[i]
+			}
+			indentedValue := strings.Join(valueLines, "\n")
+			lines = append(lines, "    * "+k+": "+indentedValue)
 		}
 	}
 	return strings.Join(lines, "\n")

--- a/internal/change.go
+++ b/internal/change.go
@@ -10,6 +10,10 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/iancoleman/strcase"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type Change struct {
@@ -102,7 +106,8 @@ func (cs Changes) Message() string {
 				valueLines[i] = "        " + valueLines[i]
 			}
 			indentedValue := strings.Join(valueLines, "\n")
-			lines = append(lines, "    * "+k+": "+indentedValue)
+			niceKey := cases.Title(language.English).String(strcase.ToDelimited(k, ' '))
+			lines = append(lines, "    * "+niceKey+": "+indentedValue)
 		}
 	}
 	return strings.Join(lines, "\n")

--- a/internal/change.go
+++ b/internal/change.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -16,6 +17,7 @@ type Change struct {
 	ResourceName string
 	OldVersion   string
 	NewVersion   string
+	Metadata     map[string]string
 	File         string
 	FileFormat   FileFormat
 	LineNum      int
@@ -86,11 +88,16 @@ func (cs Changes) Title() string {
 
 func (cs Changes) Message() string {
 	lines := []string{}
-	if len(cs) > 1 {
-		lines = append(lines, "Update", "")
-	}
 	for _, c := range cs {
-		lines = append(lines, c.Message())
+		lines = append(lines, "* "+c.Message())
+		metadataKeys := make([]string, 0)
+		for k, _ := range c.Metadata {
+			metadataKeys = append(metadataKeys, k)
+		}
+		sort.Strings(metadataKeys)
+		for _, k := range metadataKeys {
+			lines = append(lines, "    * "+k+": "+c.Metadata[k])
+		}
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/change_test.go
+++ b/internal/change_test.go
@@ -9,7 +9,7 @@ import (
 var c1 = Change{
 	RegistryName: "my-registry",
 	ResourceName: "my-resource",
-	Metadata:     map[string]string{"First": "1", "Second": "2"},
+	Metadata:     map[string]string{"someNumber": "1", "anotherNumber": "2"},
 	OldVersion:   "1.0.0",
 	NewVersion:   "2.0.0",
 	OldValue:     "my-image:1.0.0",
@@ -52,8 +52,8 @@ func TestChangesTitle(t *testing.T) {
 }
 
 func TestChangesMessage(t *testing.T) {
-	assert.Equal(t, "* Update folder/file.yaml:3 from my-image:1.0.0 to my-image:2.0.0\n    * First: 1\n    * Second: 2", Changes{c1}.Message())
-	assert.Equal(t, "* Update folder/file.yaml:3 from my-image:1.0.0 to my-image:2.0.0\n    * First: 1\n    * Second: 2\n* Update folder/file2.yaml:10 from my-image2:3.0.0 to my-image2:4.0.0", Changes{c1, c2}.Message())
+	assert.Equal(t, "* Update folder/file.yaml:3 from my-image:1.0.0 to my-image:2.0.0\n    * Another Number: 2\n    * Some Number: 1", Changes{c1}.Message())
+	assert.Equal(t, "* Update folder/file.yaml:3 from my-image:1.0.0 to my-image:2.0.0\n    * Another Number: 2\n    * Some Number: 1\n* Update folder/file2.yaml:10 from my-image2:3.0.0 to my-image2:4.0.0", Changes{c1, c2}.Message())
 
 	assert.Equal(t, "* Update folder/file3.yaml:16 from my-image3:5.0.0 to my-image3:6.0.0\n    * Message: Hello\n        \n        World", Changes{c3}.Message())
 }

--- a/internal/change_test.go
+++ b/internal/change_test.go
@@ -9,6 +9,7 @@ import (
 var c1 = Change{
 	RegistryName: "my-registry",
 	ResourceName: "my-resource",
+	Metadata:     map[string]string{"First": "1", "Second": "2"},
 	OldVersion:   "1.0.0",
 	NewVersion:   "2.0.0",
 	OldValue:     "my-image:1.0.0",
@@ -36,6 +37,11 @@ func TestChangeIdentifier(t *testing.T) {
 func TestChangesTitle(t *testing.T) {
 	assert.Equal(t, "Update my-registry/my-resource:2.0.0", Changes{c1}.Title())
 	assert.Equal(t, "Update my-registry/my-resource:2.0.0, my-registry2/my-resource2:4.0.0", Changes{c1, c2}.Title())
+}
+
+func TestChangesMessage(t *testing.T) {
+	assert.Equal(t, "* Update folder/file.yaml:3 from my-image:1.0.0 to my-image:2.0.0\n    * First: 1\n    * Second: 2", Changes{c1}.Message())
+	assert.Equal(t, "* Update folder/file.yaml:3 from my-image:1.0.0 to my-image:2.0.0\n    * First: 1\n    * Second: 2\n* Update folder/file2.yaml:10 from my-image2:3.0.0 to my-image2:4.0.0", Changes{c1, c2}.Message())
 }
 
 func TestChangesBranch(t *testing.T) {

--- a/internal/change_test.go
+++ b/internal/change_test.go
@@ -29,6 +29,18 @@ var c2 = Change{
 	LineNum:      10,
 }
 
+var c3 = Change{
+	RegistryName: "my-registry3",
+	ResourceName: "my-resource3",
+	Metadata:     map[string]string{"Message": "Hello\n\nWorld"},
+	OldVersion:   "5.0.0",
+	NewVersion:   "6.0.0",
+	OldValue:     "my-image3:5.0.0",
+	NewValue:     "my-image3:6.0.0",
+	File:         "folder/file3.yaml",
+	LineNum:      16,
+}
+
 func TestChangeIdentifier(t *testing.T) {
 	assert.Equal(t, "folder/file.yaml#3#my-image:2.0.0", c1.Identifier())
 	assert.Equal(t, "folder/file2.yaml#10#my-image2:4.0.0", c2.Identifier())
@@ -42,6 +54,8 @@ func TestChangesTitle(t *testing.T) {
 func TestChangesMessage(t *testing.T) {
 	assert.Equal(t, "* Update folder/file.yaml:3 from my-image:1.0.0 to my-image:2.0.0\n    * First: 1\n    * Second: 2", Changes{c1}.Message())
 	assert.Equal(t, "* Update folder/file.yaml:3 from my-image:1.0.0 to my-image:2.0.0\n    * First: 1\n    * Second: 2\n* Update folder/file2.yaml:10 from my-image2:3.0.0 to my-image2:4.0.0", Changes{c1, c2}.Message())
+
+	assert.Equal(t, "* Update folder/file3.yaml:16 from my-image3:5.0.0 to my-image3:6.0.0\n    * Message: Hello\n        \n        World", Changes{c3}.Message())
 }
 
 func TestChangesBranch(t *testing.T) {

--- a/internal/git_github.go
+++ b/internal/git_github.go
@@ -29,7 +29,7 @@ func (p GitHubGitProvider) Push(dir string, changes Changes, callbacks ...func()
 		return fmt.Errorf("unable to open git worktree: %w", err)
 	}
 
-	_, err = applyChangesAsCommit(*worktree, dir, changes, changes.Message(), p.Author, callbacks...)
+	_, err = applyChangesAsCommit(*worktree, dir, changes, changes.Title()+"\n\n"+changes.Message(), p.Author, callbacks...)
 	if err != nil {
 		return fmt.Errorf("unable to commit changes: %w", err)
 	}
@@ -72,7 +72,7 @@ func (p GitHubGitProvider) Request(dir string, changes Changes, callbacks ...fun
 	if err != nil {
 		return fmt.Errorf("unable to create target branch: %w", err)
 	}
-	_, err = applyChangesAsCommit(*worktree, dir, changes, changes.Message(), p.Author, callbacks...)
+	_, err = applyChangesAsCommit(*worktree, dir, changes, changes.Title()+"\n\n"+changes.Message(), p.Author, callbacks...)
 	if err != nil {
 		return fmt.Errorf("unable to commit changes: %w", err)
 	}

--- a/internal/git_gitlab.go
+++ b/internal/git_gitlab.go
@@ -29,7 +29,7 @@ func (p GitLabGitProvider) Push(dir string, changes Changes, callbacks ...func()
 		return fmt.Errorf("unable to open git worktree: %w", err)
 	}
 
-	_, err = applyChangesAsCommit(*worktree, dir, changes, changes.Message(), p.Author, callbacks...)
+	_, err = applyChangesAsCommit(*worktree, dir, changes, changes.Title()+"\n\n"+changes.Message(), p.Author, callbacks...)
 	if err != nil {
 		return fmt.Errorf("unable to commit changes: %w", err)
 	}
@@ -72,7 +72,7 @@ func (p GitLabGitProvider) Request(dir string, changes Changes, callbacks ...fun
 	if err != nil {
 		return fmt.Errorf("unable to create target branch: %w", err)
 	}
-	_, err = applyChangesAsCommit(*worktree, dir, changes, changes.Message(), p.Author, callbacks...)
+	_, err = applyChangesAsCommit(*worktree, dir, changes, changes.Title()+"\n\n"+changes.Message(), p.Author, callbacks...)
 	if err != nil {
 		return fmt.Errorf("unable to commit changes: %w", err)
 	}

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -12,4 +12,5 @@ type HttpBasicCredentials struct {
 type Registry interface {
 	GetInterval() time.Duration
 	FetchVersions(resource string) ([]string, error)
+	RetrieveMetadata(resource string, version string) (map[string]string, error)
 }

--- a/internal/registry_docker.go
+++ b/internal/registry_docker.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"regexp"
@@ -24,17 +25,11 @@ func (r DockerRegistry) GetInterval() time.Duration {
 }
 
 func (r DockerRegistry) FetchVersions(repository string) ([]string, error) {
-	type tagsPage struct {
+	type tagsPageJson struct {
 		Name string   `json:"name"`
 		Tags []string `json:"tags"`
 	}
-
-	url := strings.TrimSuffix(r.Url, "/")
-	username := r.Credentials.Username
-	password := r.Credentials.Password
-	client := http.Client{
-		Transport: dockerWrapTransport(http.DefaultTransport, url, username, password),
-	}
+	client, url := r.createClient()
 
 	result := []string{}
 	nextLink := url + "/v2/" + repository + "/tags/list"
@@ -51,12 +46,12 @@ func (r DockerRegistry) FetchVersions(repository string) ([]string, error) {
 			return nil, err
 		}
 
-		var tagPage tagsPage
-		err = json.Unmarshal(respBody, &tagPage)
+		var tagsPage tagsPageJson
+		err = json.Unmarshal(respBody, &tagsPage)
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, tagPage.Tags...)
+		result = append(result, tagsPage.Tags...)
 
 		nextLink = dockerGetNextLink(resp)
 		if strings.HasPrefix(nextLink, "/") {
@@ -65,6 +60,141 @@ func (r DockerRegistry) FetchVersions(repository string) ([]string, error) {
 	}
 
 	return result, nil
+}
+
+func (r DockerRegistry) RetrieveMetadata(repository string, version string) (map[string]string, error) {
+	type manifestConfigJson struct {
+		MediaType string `json:"mediaType"`
+		Digest    string `json:"digest"`
+		Size      int64  `json:"size"`
+	}
+	type manifestLayerJson struct {
+		MediaType string `json:"mediaType"`
+		Digest    string `json:"digest"`
+		Size      int64  `json:"size"`
+	}
+	type manifestJson struct {
+		MediaType     string              `json:"mediaType"`
+		SchemaVersion int                 `json:"schemaVersion"`
+		Config        manifestConfigJson  `json:"config"`
+		Layers        []manifestLayerJson `json:"layers"`
+	}
+	type manifestListManifestJson struct {
+		MediaType string `json:"mediaType"`
+		Digest    string `json:"digest"`
+		Size      int64  `json:"size"`
+		// Platform
+	}
+	type manifestListJson struct {
+		MediaType     string                     `json:"mediaType"`
+		SchemaVersion int                        `json:"schemaVersion"`
+		Manifests     []manifestListManifestJson `json:"manifests"`
+	}
+	type configConfigJson struct {
+		Labels map[string]string `json:"Labels"`
+		// rest omitted
+	}
+	type configJson struct {
+		Config configConfigJson `json:"config"`
+		// rest omitted
+	}
+	client, url := r.createClient()
+
+	req, err := http.NewRequest("GET", url+"/v2/"+repository+"/manifests/"+version, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	manifests := []manifestJson{}
+
+	if resp.Header.Get("content-type") == "application/vnd.docker.distribution.manifest.v2+json" {
+		var manifest manifestJson
+		err = json.Unmarshal(respBody, &manifest)
+		if err != nil {
+			return nil, err
+		}
+		manifests = append(manifests, manifest)
+	} else if resp.Header.Get("content-type") == "application/vnd.docker.distribution.manifest.list.v2+json" {
+		var manifestList manifestListJson
+		err = json.Unmarshal(respBody, &manifestList)
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range manifestList.Manifests {
+			req2, err := http.NewRequest("GET", url+"/v2/"+repository+"/manifests/"+m.Digest, nil)
+			if err != nil {
+				return nil, err
+			}
+			req2.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+			resp2, err := client.Do(req2)
+			if err != nil {
+				return nil, err
+			}
+			defer resp2.Body.Close()
+			resp2Body, err := ioutil.ReadAll(resp2.Body)
+			if err != nil {
+				return nil, err
+			}
+
+			var manifest manifestJson
+			err = json.Unmarshal(resp2Body, &manifest)
+			if err != nil {
+				return nil, err
+			}
+			manifests = append(manifests, manifest)
+		}
+	} else {
+		return nil, fmt.Errorf("unexpected content type %s", req.Header.Get("content-type"))
+	}
+
+	result := map[string]string{}
+
+	for _, m := range manifests {
+		req3, err := http.NewRequest("GET", url+"/v2/"+repository+"/blobs/"+m.Config.Digest, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp3, err := client.Do(req3)
+		if err != nil {
+			return nil, err
+		}
+		defer resp3.Body.Close()
+		resp3Body, err := ioutil.ReadAll(resp3.Body)
+		if err != nil {
+			return nil, err
+		}
+		var config configJson
+		err = json.Unmarshal(resp3Body, &config)
+		if err != nil {
+			return nil, err
+		}
+
+		for k, v := range config.Config.Labels {
+			result["Label "+k] = v
+		}
+	}
+
+	return result, nil
+}
+
+func (r DockerRegistry) createClient() (http.Client, string) {
+	url := strings.TrimSuffix(r.Url, "/")
+	username := r.Credentials.Username
+	password := r.Credentials.Password
+	client := http.Client{
+		Transport: dockerWrapTransport(http.DefaultTransport, url, username, password),
+	}
+	return client, url
 }
 
 func dockerWrapTransport(transport http.RoundTripper, url, username, password string) http.RoundTripper {

--- a/internal/registry_docker.go
+++ b/internal/registry_docker.go
@@ -180,7 +180,7 @@ func (r DockerRegistry) RetrieveMetadata(repository string, version string) (map
 		}
 
 		for k, v := range config.Config.Labels {
-			result["Label "+k] = v
+			result[k] = v
 		}
 	}
 

--- a/internal/registry_docker_test.go
+++ b/internal/registry_docker_test.go
@@ -10,7 +10,6 @@ func TestDockerFetchVersions(t *testing.T) {
 	reg1 := DockerRegistry{
 		Url: "https://registry-1.docker.io",
 	}
-
 	output1, err := reg1.FetchVersions("library/nginx")
 	assert.NoError(t, err)
 	assert.Greater(t, len(output1), 0)
@@ -18,8 +17,23 @@ func TestDockerFetchVersions(t *testing.T) {
 	reg2 := DockerRegistry{
 		Url: "https://quay.io",
 	}
-
 	output2, err := reg2.FetchVersions("oauth2-proxy/oauth2-proxy")
 	assert.NoError(t, err)
 	assert.Greater(t, len(output2), 0)
+}
+
+func TestDockerRetrieveMetadata(t *testing.T) {
+	reg1 := DockerRegistry{
+		Url: "https://registry-1.docker.io",
+	}
+	output1, err := reg1.RetrieveMetadata("library/nginx", "1.23.0")
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"Label maintainer": "NGINX Docker Maintainers <docker-maint@nginx.com>"}, output1)
+
+	reg2 := DockerRegistry{
+		Url: "https://quay.io",
+	}
+	output2, err := reg2.RetrieveMetadata("oauth2-proxy/oauth2-proxy", "v7.3.0")
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{}, output2)
 }

--- a/internal/registry_docker_test.go
+++ b/internal/registry_docker_test.go
@@ -28,7 +28,7 @@ func TestDockerRetrieveMetadata(t *testing.T) {
 	}
 	output1, err := reg1.RetrieveMetadata("library/nginx", "1.23.0")
 	assert.NoError(t, err)
-	assert.Equal(t, map[string]string{"Label maintainer": "NGINX Docker Maintainers <docker-maint@nginx.com>"}, output1)
+	assert.Equal(t, map[string]string{"maintainer": "NGINX Docker Maintainers <docker-maint@nginx.com>"}, output1)
 
 	reg2 := DockerRegistry{
 		Url: "https://quay.io",

--- a/internal/registry_github_tag.go
+++ b/internal/registry_github_tag.go
@@ -74,5 +74,5 @@ func (r GitHubTagRegistry) FetchVersions(repository string) ([]string, error) {
 
 func (r GitHubTagRegistry) RetrieveMetadata(resource string, version string) (map[string]string, error) {
 	url := fmt.Sprintf("https://github.com/%s/releases/tag/%s", resource, version)
-	return map[string]string{"Release": url}, nil
+	return map[string]string{"releaseUrl": url}, nil
 }

--- a/internal/registry_github_tag.go
+++ b/internal/registry_github_tag.go
@@ -71,3 +71,8 @@ func (r GitHubTagRegistry) FetchVersions(repository string) ([]string, error) {
 
 	return result, nil
 }
+
+func (r GitHubTagRegistry) RetrieveMetadata(resource string, version string) (map[string]string, error) {
+	url := fmt.Sprintf("https://github.com/%s/releases/tag/%s", resource, version)
+	return map[string]string{"Release": url}, nil
+}

--- a/internal/registry_helm.go
+++ b/internal/registry_helm.go
@@ -69,3 +69,7 @@ func (r HelmRegistry) FetchVersions(chart string) ([]string, error) {
 
 	return result, nil
 }
+
+func (r HelmRegistry) RetrieveMetadata(resource string, version string) (map[string]string, error) {
+	return nil, nil
+}

--- a/internal/update.go
+++ b/internal/update.go
@@ -143,9 +143,15 @@ func DetectUpdates(dir string, config Config, cacheProvider CacheProvider) []Upd
 					errs = append(errs, fmt.Errorf("%s:%d: %w", fileRel, fileAnnotation.LineNum, err))
 					continue
 				}
+				metadata, err := (*annotation.Registry).RetrieveMetadata(annotation.ResourceName, *nextVersion)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("%s:%d: %w", fileRel, fileAnnotation.LineNum, err))
+					continue
+				}
 				change := Change{
 					RegistryName: annotation.RegistryName,
 					ResourceName: annotation.ResourceName,
+					Metadata:     metadata,
 					OldVersion:   *currentVersion,
 					NewVersion:   *nextVersion,
 					File:         fileRel,


### PR DESCRIPTION
Every registry implementation can provide a key-value map of metadata
that will be added to the create commits and pull requests.