### PR TITLE
Add commit message augmenter strategy

### DIFF
--- a/cmd/find.go
+++ b/cmd/find.go
@@ -82,7 +82,7 @@ var (
 						err := internal.ApplyUpdate(dir, *config, cacheProvider, *r.Action, *r.Change)
 						if err != nil {
 							errorCount += 1
-							internal.LogError("%v", r.Error)
+							internal.LogError("%v", err)
 						} else {
 							internal.LogInfo("%s:%d the version was updated from %s to %s", r.Change.File, r.Change.LineNum, r.Change.OldVersion, r.Change.NewVersion)
 						}

--- a/go.mod
+++ b/go.mod
@@ -24,9 +24,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4
 	github.com/fatih/color v1.13.0
 	github.com/go-git/go-billy/v5 v5.3.1
-	github.com/iancoleman/strcase v0.2.0
 	github.com/xanzy/go-gitlab v0.76.0
-	golang.org/x/text v0.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,6 @@ github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh
 github.com/heroku/docker-registry-client v0.0.0-20211012143308-9463674c8930 h1:mNL9ktJqBuzPTV/QP/fKd4y1uOFvfiv6zhe0G7lg9OA=
 github.com/heroku/docker-registry-client v0.0.0-20211012143308-9463674c8930/go.mod h1:Yho0S7KhsnHQRCC5lDraYF1SsLMeWtf/tKdufKu3TJA=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
-github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
@@ -294,7 +292,6 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
-golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/time v0.2.0 h1:52I/1L54xyEQAYdtcSuxtiT84KGYTBGXwayxmIpNJhE=
 golang.org/x/time v0.2.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20170915040203-e531a2a1c15f/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/action.go
+++ b/internal/action.go
@@ -38,10 +38,6 @@ func (c RequestAction) Identifier() string {
 }
 
 func (a RequestAction) Apply(dir string, changes Changes) error {
-	alreadyDone := a.git.AlreadyRequested(dir, changes)
-	if alreadyDone {
-		return nil
-	}
 	return a.git.Request(dir, changes, execCallbacks(dir, a.exec)...)
 }
 

--- a/internal/augmenter.go
+++ b/internal/augmenter.go
@@ -1,0 +1,5 @@
+package internal
+
+type Augmenter interface {
+	RenderMessage(config Config, change Change) (string, error)
+}

--- a/internal/augmenter_github.go
+++ b/internal/augmenter_github.go
@@ -1,0 +1,87 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/google/go-github/v40/github"
+	"golang.org/x/oauth2"
+)
+
+var _ Augmenter = (*GithubAugmenter)(nil)
+
+type GithubAugmenter struct {
+	AccessToken string
+}
+
+func (a GithubAugmenter) RenderMessage(config Config, change Change) (string, error) {
+	registry, ok := config.Registries[change.RegistryName]
+	if !ok {
+		return "", nil
+	}
+	dockerRegistry, ok := registry.(DockerRegistry)
+	if !ok {
+		return "", nil
+	}
+
+	oldLabels, err := dockerRegistry.RetrieveLabels(change.ResourceName, change.OldVersion)
+	if err != nil {
+		return "", err
+	}
+	newLabels, err := dockerRegistry.RetrieveLabels(change.ResourceName, change.NewVersion)
+	if err != nil {
+		return "", err
+	}
+
+	oldSource := oldLabels["org.opencontainers.image.source"]
+	oldRevision := oldLabels["org.opencontainers.image.revision"]
+	newSource := newLabels["org.opencontainers.image.source"]
+	newRevision := newLabels["org.opencontainers.image.revision"]
+
+	githubSourceRegex := regexp.MustCompile(`^https://github.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)$`)
+	oldGithubSourceMatch := githubSourceRegex.FindStringSubmatch(oldSource)
+	newGithubSourceMatch := githubSourceRegex.FindStringSubmatch(newSource)
+	githubCommitRegex := regexp.MustCompile(`^(?P<hash>[0-9a-f]{40})$`)
+	oldGithubCommitMatch := githubCommitRegex.FindStringSubmatch(oldRevision)
+	newGithubCommitMatch := githubCommitRegex.FindStringSubmatch(newRevision)
+
+	if newGithubSourceMatch != nil && oldGithubSourceMatch != nil && newGithubSourceMatch[2] == oldGithubSourceMatch[2] && newGithubSourceMatch[1] == oldGithubSourceMatch[1] && newGithubCommitMatch != nil && oldGithubCommitMatch != nil {
+		owner := newGithubSourceMatch[1]
+		repo := newGithubSourceMatch[2]
+		base := oldGithubCommitMatch[1]
+		head := newGithubCommitMatch[1]
+
+		result := fmt.Sprintf("https://github.com/%s/%s/compare/%s...%s", owner, repo, base, head) + "\n\n"
+
+		ctx := context.Background()
+		client := github.NewClient(&http.Client{})
+		if a.AccessToken != "" {
+			ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: a.AccessToken})
+			tc := oauth2.NewClient(ctx, ts)
+			client = github.NewClient(tc)
+		}
+		comparison, res, err := client.Repositories.CompareCommits(ctx, owner, repo, base, head, &github.ListOptions{
+			PerPage: 100,
+		})
+		defer res.Body.Close()
+		if err == nil && comparison != nil {
+			for _, commit := range comparison.Commits {
+				if commit.Commit != nil && commit.HTMLURL != nil && commit.Commit.Message != nil {
+					result = result + fmt.Sprintf("* %s %s", *commit.Commit.Message, *commit.HTMLURL) + "\n"
+				}
+			}
+		}
+
+		return strings.Trim(result, "\n "), nil
+	} else if newGithubSourceMatch != nil && newGithubCommitMatch != nil {
+		owner := newGithubSourceMatch[1]
+		repo := newGithubSourceMatch[2]
+		head := newGithubCommitMatch[1]
+		return fmt.Sprintf("https://github.com/%s/%s/commit/%s", owner, repo, head), nil
+	}
+
+	return "", nil
+}

--- a/internal/augmenter_github_test.go
+++ b/internal/augmenter_github_test.go
@@ -32,3 +32,37 @@ func TestGithubAugmenterRenderMessage(t *testing.T) {
 		)
 	}
 }
+
+func TestGithubAugmenterExtractPullRequestLinks(t *testing.T) {
+	a := GithubAugmenter{}
+
+	t.Run("empty", func(t *testing.T) {
+		text, prs := a.ExtractPullRequestLinks("airfocusio", "git-ops-update", "")
+		assert.Equal(t, "", text)
+		assert.Equal(t, []string{}, prs)
+	})
+
+	t.Run("none", func(t *testing.T) {
+		text, prs := a.ExtractPullRequestLinks("airfocusio", "git-ops-update", "Hello World")
+		assert.Equal(t, "Hello World", text)
+		assert.Equal(t, []string{}, prs)
+	})
+
+	t.Run("single", func(t *testing.T) {
+		text, prs := a.ExtractPullRequestLinks("airfocusio", "git-ops-update", "Hello World #1")
+		assert.Equal(t, "Hello World", text)
+		assert.Equal(t, []string{"https://github.com/airfocusio/git-ops-update/pull/1"}, prs)
+	})
+
+	t.Run("single in parentheses", func(t *testing.T) {
+		text, prs := a.ExtractPullRequestLinks("airfocusio", "git-ops-update", "Hello World (#1)")
+		assert.Equal(t, "Hello World", text)
+		assert.Equal(t, []string{"https://github.com/airfocusio/git-ops-update/pull/1"}, prs)
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		text, prs := a.ExtractPullRequestLinks("airfocusio", "git-ops-update", "Hello World (#1)\n\nAnother one (#234)")
+		assert.Equal(t, "Hello World\n\nAnother one", text)
+		assert.Equal(t, []string{"https://github.com/airfocusio/git-ops-update/pull/1", "https://github.com/airfocusio/git-ops-update/pull/234"}, prs)
+	})
+}

--- a/internal/augmenter_github_test.go
+++ b/internal/augmenter_github_test.go
@@ -1,0 +1,34 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGithubAugmenterRenderMessage(t *testing.T) {
+	c := Config{
+		Registries: map[string]Registry{
+			"docker": DockerRegistry{
+				Url: "https://ghcr.io",
+			},
+		},
+	}
+	a := GithubAugmenter{}
+	m, err := a.RenderMessage(c, Change{
+		RegistryName: "docker",
+		ResourceName: "airfocusio/git-ops-update-test",
+		OldVersion:   "docker-v2-manifest-v0.0.1",
+		NewVersion:   "docker-v2-manifest-v0.0.2",
+	})
+	if assert.NoError(t, err) {
+		assert.Equal(
+			t,
+			"https://github.com/airfocusio/git-ops-update/compare/99a7aaa2eff5aff7c77d9caf0901454fedf6bf00...700688d22e0b5c1ce02d341c42d0bf7c11e80aaa\n"+
+				"\n"+
+				"* add file1.txt https://github.com/airfocusio/git-ops-update/commit/0246e72c58f839d09ff0975f80955c0666f168ca\n"+
+				"* add file2.txt v0.0.2 https://github.com/airfocusio/git-ops-update/commit/700688d22e0b5c1ce02d341c42d0bf7c11e80aaa",
+			m,
+		)
+	}
+}

--- a/internal/change_test.go
+++ b/internal/change_test.go
@@ -9,13 +9,13 @@ import (
 var c1 = Change{
 	RegistryName: "my-registry",
 	ResourceName: "my-resource",
-	Metadata:     map[string]string{"someNumber": "1", "anotherNumber": "2"},
 	OldVersion:   "1.0.0",
 	NewVersion:   "2.0.0",
 	OldValue:     "my-image:1.0.0",
 	NewValue:     "my-image:2.0.0",
 	File:         "folder/file.yaml",
 	LineNum:      3,
+	Comments:     "Line",
 }
 
 var c2 = Change{
@@ -27,12 +27,12 @@ var c2 = Change{
 	NewValue:     "my-image2:4.0.0",
 	File:         "folder/file2.yaml",
 	LineNum:      10,
+	Comments:     "Multi\nLine\n",
 }
 
 var c3 = Change{
 	RegistryName: "my-registry3",
 	ResourceName: "my-resource3",
-	Metadata:     map[string]string{"Message": "Hello\n\nWorld"},
 	OldVersion:   "5.0.0",
 	NewVersion:   "6.0.0",
 	OldValue:     "my-image3:5.0.0",
@@ -52,10 +52,10 @@ func TestChangesTitle(t *testing.T) {
 }
 
 func TestChangesMessage(t *testing.T) {
-	assert.Equal(t, "* Update folder/file.yaml:3 from my-image:1.0.0 to my-image:2.0.0\n    * Another Number: 2\n    * Some Number: 1", Changes{c1}.Message())
-	assert.Equal(t, "* Update folder/file.yaml:3 from my-image:1.0.0 to my-image:2.0.0\n    * Another Number: 2\n    * Some Number: 1\n* Update folder/file2.yaml:10 from my-image2:3.0.0 to my-image2:4.0.0", Changes{c1, c2}.Message())
+	assert.Equal(t, "Update folder/file.yaml:3 from my-image:1.0.0 to my-image:2.0.0\nLine", Changes{c1}.Message())
+	assert.Equal(t, "Update folder/file.yaml:3 from my-image:1.0.0 to my-image:2.0.0\nLine\n\n---\n\nUpdate folder/file2.yaml:10 from my-image2:3.0.0 to my-image2:4.0.0\nMulti\nLine", Changes{c1, c2}.Message())
 
-	assert.Equal(t, "* Update folder/file3.yaml:16 from my-image3:5.0.0 to my-image3:6.0.0\n    * Message: Hello\n        \n        World", Changes{c3}.Message())
+	assert.Equal(t, "Update folder/file3.yaml:16 from my-image3:5.0.0 to my-image3:6.0.0", Changes{c3}.Message())
 }
 
 func TestChangesBranch(t *testing.T) {

--- a/internal/change_test.go
+++ b/internal/change_test.go
@@ -41,9 +41,16 @@ var c3 = Change{
 	LineNum:      16,
 }
 
-func TestChangeIdentifier(t *testing.T) {
-	assert.Equal(t, "folder/file.yaml#3#my-image:2.0.0", c1.Identifier())
-	assert.Equal(t, "folder/file2.yaml#10#my-image2:4.0.0", c2.Identifier())
+func TestChangesGroupHash(t *testing.T) {
+	assert.Equal(t, "cdb34bd928617494", Changes{c1}.GroupHash())
+	assert.Equal(t, "79baa33623f66cab", Changes{c2}.GroupHash())
+	assert.Equal(t, "7828b1505ed039e7", Changes{c1, c2}.GroupHash())
+}
+
+func TestChangesHash(t *testing.T) {
+	assert.Equal(t, "f947389f23a7d6f7", Changes{c1}.Hash())
+	assert.Equal(t, "c3de406196d88bed", Changes{c2}.Hash())
+	assert.Equal(t, "cf0b28c1d50d0788", Changes{c1, c2}.Hash())
 }
 
 func TestChangesTitle(t *testing.T) {
@@ -59,6 +66,6 @@ func TestChangesMessage(t *testing.T) {
 }
 
 func TestChangesBranch(t *testing.T) {
-	assert.Equal(t, "git-ops-update/my-registry-my-resource-2.0.0/f947389f23a7d6f7", Changes{c1}.Branch("git-ops-update"))
-	assert.Equal(t, "git-ops-update/my-registry-my-resource-2.0.0-my-registry2-my-resource2-4.0.0/cf0b28c1d50d0788", Changes{c1, c2}.Branch("git-ops-update"))
+	assert.Equal(t, "git-ops-update/my-registry-my-resource-2.0.0/cdb34bd928617494/f947389f23a7d6f7", Changes{c1}.Branch("git-ops-update"))
+	assert.Equal(t, "git-ops-update/my-registry-my-resource-2.0.0-my-registry2-my-resource2-4.0.0/7828b1505ed039e7/cf0b28c1d50d0788", Changes{c1, c2}.Branch("git-ops-update"))
 }

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -86,6 +86,11 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		},
+		Augmenters: []Augmenter{
+			GithubAugmenter{
+				AccessToken: "access_token",
+			},
+		},
 		Git: Git{
 			Provider: GitHubGitProvider{
 				Author: GitAuthor{
@@ -100,5 +105,6 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, c2.Files, c1.Files)
 	assert.Equal(t, c2.Registries, c1.Registries)
 	assert.Equal(t, c2.Policies, c1.Policies)
+	assert.Equal(t, c2.Augmenters, c1.Augmenters)
 	assert.Equal(t, c2.Git, c1.Git)
 }

--- a/internal/config_test.yaml
+++ b/internal/config_test.yaml
@@ -46,6 +46,9 @@ policies:
       pinMinor: true
       pinPatch: true
       allowPrereleases: true
+augmenters:
+- type: gitHub
+  accessToken: access_token
 git:
   author:
     name: name

--- a/internal/git.go
+++ b/internal/git.go
@@ -18,7 +18,6 @@ type Git struct {
 type GitProvider interface {
 	Push(dir string, changes Changes, callbacks ...func() error) error
 	Request(dir string, changes Changes, callbacks ...func() error) error
-	AlreadyRequested(dir string, changes Changes) bool
 }
 
 type GitAuthor struct {

--- a/internal/git_github.go
+++ b/internal/git_github.go
@@ -91,7 +91,7 @@ func (p GitHubGitProvider) Request(dir string, changes Changes, callbacks ...fun
 				},
 			})
 			if err != nil {
-				return err
+				LogWarning("Unable to remove branch %s from github repository %s/%s: %v", refName, *ownerName, *repoName, err)
 			}
 		}
 	}

--- a/internal/git_github.go
+++ b/internal/git_github.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 
@@ -60,8 +61,42 @@ func (p GitHubGitProvider) Request(dir string, changes Changes, callbacks ...fun
 	if err != nil {
 		return fmt.Errorf("unable to get git remote origin: %w", err)
 	}
+	remoteRefs, err := remote.List(&git.ListOptions{
+		Auth: &http.BasicAuth{
+			Username: "api",
+			Password: p.AccessToken,
+		},
+	})
 	if err != nil {
 		return fmt.Errorf("unable to list git branches: %w", err)
+	}
+	ownerName, repoName, err := extractGitHubOwnerRepoFromRemote(*remote)
+	if err != nil {
+		return fmt.Errorf("unable to extract github owner/repository from remote origin: %w", err)
+	}
+
+	targetBranchFindPrefix := fmt.Sprintf("refs/heads/%s", changes.BranchFindPrefix(branchPrefix))
+	targetBranchGroupHash := changes.GroupHash()
+	targetBranchHash := changes.Hash()
+	targetBranchExists := false
+	for _, ref := range remoteRefs {
+		refName := ref.Name().String()
+		if strings.HasPrefix(refName, targetBranchFindPrefix) && strings.Contains(refName, targetBranchHash) {
+			targetBranchExists = true
+		} else if strings.HasPrefix(refName, targetBranchFindPrefix) && strings.Contains(refName, targetBranchGroupHash) {
+			LogDebug("Removing branch %s from github repository %s/%s", refName, *ownerName, *repoName)
+			err := remote.Push(&git.PushOptions{
+				RefSpecs: []config.RefSpec{
+					config.RefSpec(":" + refName),
+				},
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if targetBranchExists {
+		return nil
 	}
 	targetBranch := plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", changes.Branch(branchPrefix)))
 
@@ -88,10 +123,6 @@ func (p GitHubGitProvider) Request(dir string, changes Changes, callbacks ...fun
 		return fmt.Errorf("unable to push changes: %w", err)
 	}
 
-	ownerName, repoName, err := extractGitHubOwnerRepoFromRemote(*remote)
-	if err != nil {
-		return fmt.Errorf("unable to extract github owner/repository from remote origin: %w", err)
-	}
 	LogDebug("Creating pull request for branch %s to github repository %s/%s", targetBranch.Short(), *ownerName, *repoName)
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: p.AccessToken})
@@ -117,37 +148,6 @@ func (p GitHubGitProvider) Request(dir string, changes Changes, callbacks ...fun
 		return fmt.Errorf("unable to checkout to base branch: %w", err)
 	}
 	return nil
-}
-
-func (p GitHubGitProvider) AlreadyRequested(dir string, changes Changes) bool {
-	repo, err := git.PlainOpen(dir)
-	if err != nil {
-		return false
-	}
-	remote, err := repo.Remote("origin")
-	if err != nil {
-		return false
-	}
-	remoteRefs, err := remote.List(&git.ListOptions{
-		Auth: &http.BasicAuth{
-			Username: "api",
-			Password: p.AccessToken,
-		},
-	})
-	if err != nil {
-		return false
-	}
-	targetBranchFindPrefix := fmt.Sprintf("refs/heads/%s", changes.BranchFindPrefix(branchPrefix))
-	targetBranchFindSuffix := changes.BranchFindSuffix()
-	targetBranchExists := false
-	for _, ref := range remoteRefs {
-		refName := ref.Name().String()
-		if strings.HasPrefix(refName, targetBranchFindPrefix) && strings.HasSuffix(refName, targetBranchFindSuffix) {
-			targetBranchExists = true
-			break
-		}
-	}
-	return targetBranchExists
 }
 
 func extractGitHubOwnerRepoFromRemote(remote git.Remote) (*string, *string, error) {

--- a/internal/git_github.go
+++ b/internal/git_github.go
@@ -86,6 +86,10 @@ func (p GitHubGitProvider) Request(dir string, changes Changes, callbacks ...fun
 		} else if strings.HasPrefix(refName, targetBranchFindPrefix) && strings.Contains(refName, targetBranchGroupHash) {
 			LogDebug("Removing branch %s from github repository %s/%s", refName, *ownerName, *repoName)
 			err := remote.Push(&git.PushOptions{
+				Auth: &http.BasicAuth{
+					Username: "api",
+					Password: p.AccessToken,
+				},
 				RefSpecs: []config.RefSpec{
 					config.RefSpec(":" + refName),
 				},

--- a/internal/git_gitlab.go
+++ b/internal/git_gitlab.go
@@ -86,6 +86,10 @@ func (p GitLabGitProvider) Request(dir string, changes Changes, callbacks ...fun
 		} else if strings.HasPrefix(refName, targetBranchFindPrefix) && strings.Contains(refName, targetBranchGroupHash) {
 			LogDebug("Removing branch %s from gitlab project %s", refName, *projectId)
 			err := remote.Push(&git.PushOptions{
+				Auth: &http.BasicAuth{
+					Username: "api",
+					Password: p.AccessToken,
+				},
 				RefSpecs: []config.RefSpec{
 					config.RefSpec(":" + refName),
 				},

--- a/internal/git_gitlab.go
+++ b/internal/git_gitlab.go
@@ -91,7 +91,7 @@ func (p GitLabGitProvider) Request(dir string, changes Changes, callbacks ...fun
 				},
 			})
 			if err != nil {
-				return err
+				LogWarning("Unable to remove branch %s from gitlab project %s: %v", refName, *projectId, err)
 			}
 		}
 	}

--- a/internal/git_local.go
+++ b/internal/git_local.go
@@ -32,7 +32,3 @@ func (p LocalGitProvider) Request(dir string, changes Changes, callbacks ...func
 	}
 	return runCallbacks(callbacks)
 }
-
-func (p LocalGitProvider) AlreadyRequested(dir string, changes Changes) bool {
-	return false
-}

--- a/internal/registry.go
+++ b/internal/registry.go
@@ -12,5 +12,4 @@ type HttpBasicCredentials struct {
 type Registry interface {
 	GetInterval() time.Duration
 	FetchVersions(resource string) ([]string, error)
-	RetrieveMetadata(resource string, version string) (map[string]string, error)
 }

--- a/internal/registry_docker.go
+++ b/internal/registry_docker.go
@@ -62,7 +62,7 @@ func (r DockerRegistry) FetchVersions(repository string) ([]string, error) {
 	return result, nil
 }
 
-func (r DockerRegistry) RetrieveMetadata(repository string, version string) (map[string]string, error) {
+func (r DockerRegistry) RetrieveLabels(repository string, version string) (map[string]string, error) {
 	type manifestConfigJson struct {
 		MediaType string `json:"mediaType"`
 		Digest    string `json:"digest"`

--- a/internal/registry_docker_test.go
+++ b/internal/registry_docker_test.go
@@ -32,44 +32,32 @@ func TestDockerRetrieveLabels(t *testing.T) {
 	t.Run("docker-v2-manifest", func(t *testing.T) {
 		output, err := reg.RetrieveLabels("airfocusio/git-ops-update-test", "docker-v2-manifest-v0.0.1")
 		assert.NoError(t, err)
-		assert.Equal(t, map[string]string{
-			"io.buildah.version":                "1.23.1",
-			"org.opencontainers.image.version":  "0.0.1",
-			"org.opencontainers.image.source":   "https://github.com/airfocusio/git-ops-update",
-			"org.opencontainers.image.revision": "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00",
-		}, output)
+		assert.Equal(t, "0.0.1", output["org.opencontainers.image.version"])
+		assert.Equal(t, "https://github.com/airfocusio/git-ops-update", output["org.opencontainers.image.source"])
+		assert.Equal(t, "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00", output["org.opencontainers.image.revision"])
 	})
 
 	t.Run("oci-v1-manifest", func(t *testing.T) {
 		output, err := reg.RetrieveLabels("airfocusio/git-ops-update-test", "oci-v1-manifest-v0.0.1")
 		assert.NoError(t, err)
-		assert.Equal(t, map[string]string{
-			"io.buildah.version":                "1.23.1",
-			"org.opencontainers.image.version":  "0.0.1",
-			"org.opencontainers.image.source":   "https://github.com/airfocusio/git-ops-update",
-			"org.opencontainers.image.revision": "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00",
-		}, output)
+		assert.Equal(t, "0.0.1", output["org.opencontainers.image.version"])
+		assert.Equal(t, "https://github.com/airfocusio/git-ops-update", output["org.opencontainers.image.source"])
+		assert.Equal(t, "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00", output["org.opencontainers.image.revision"])
 	})
 
 	t.Run("docker-v2-manifest-list", func(t *testing.T) {
 		output, err := reg.RetrieveLabels("airfocusio/git-ops-update-test", "docker-v2-manifest-list-v0.0.1")
 		assert.NoError(t, err)
-		assert.Equal(t, map[string]string{
-			"io.buildah.version":                "1.23.1",
-			"org.opencontainers.image.version":  "0.0.1",
-			"org.opencontainers.image.source":   "https://github.com/airfocusio/git-ops-update",
-			"org.opencontainers.image.revision": "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00",
-		}, output)
+		assert.Equal(t, "0.0.1", output["org.opencontainers.image.version"])
+		assert.Equal(t, "https://github.com/airfocusio/git-ops-update", output["org.opencontainers.image.source"])
+		assert.Equal(t, "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00", output["org.opencontainers.image.revision"])
 	})
 
 	t.Run("oci-v1-image-index", func(t *testing.T) {
 		output, err := reg.RetrieveLabels("airfocusio/git-ops-update-test", "oci-v1-image-index-v0.0.1")
 		assert.NoError(t, err)
-		assert.Equal(t, map[string]string{
-			"io.buildah.version":                "1.23.1",
-			"org.opencontainers.image.version":  "0.0.1",
-			"org.opencontainers.image.source":   "https://github.com/airfocusio/git-ops-update",
-			"org.opencontainers.image.revision": "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00",
-		}, output)
+		assert.Equal(t, "0.0.1", output["org.opencontainers.image.version"])
+		assert.Equal(t, "https://github.com/airfocusio/git-ops-update", output["org.opencontainers.image.source"])
+		assert.Equal(t, "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00", output["org.opencontainers.image.revision"])
 	})
 }

--- a/internal/registry_docker_test.go
+++ b/internal/registry_docker_test.go
@@ -7,87 +7,69 @@ import (
 )
 
 func TestDockerFetchVersions(t *testing.T) {
-	reg1 := DockerRegistry{
-		Url: "https://ghcr.io",
-	}
-	output1, err := reg1.FetchVersions("airfocusio/git-ops-update")
-	assert.NoError(t, err)
-	assert.Greater(t, len(output1), 0)
-
-	reg2 := DockerRegistry{
-		Url: "https://quay.io",
-	}
-	output2, err := reg2.FetchVersions("oauth2-proxy/oauth2-proxy")
-	assert.NoError(t, err)
-	assert.Greater(t, len(output2), 0)
-}
-
-func TestDockerRetrieveMetadata(t *testing.T) {
-	reg1 := DockerRegistry{
-		Url: "https://ghcr.io",
-	}
-	output1a, err := reg1.RetrieveMetadata("airfocusio/git-ops-update-test", "docker-v2-manifest-list-v0.0.1")
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]string{
-		"io.buildah.version":                "1.23.1",
-		"org.opencontainers.image.version":  "0.0.1",
-		"org.opencontainers.image.source":   "https://github.com/airfocusio/git-ops-update",
-		"org.opencontainers.image.revision": "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00",
-	}, output1a)
-
-	output1b, err := reg1.RetrieveMetadata("airfocusio/git-ops-update-test", "oci-v1-image-index-v0.0.1")
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]string{
-		"io.buildah.version":                "1.23.1",
-		"org.opencontainers.image.version":  "0.0.1",
-		"org.opencontainers.image.source":   "https://github.com/airfocusio/git-ops-update",
-		"org.opencontainers.image.revision": "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00",
-	}, output1b)
-
-	reg2 := DockerRegistry{
-		Url: "https://quay.io",
-	}
-	output2, err := reg2.RetrieveMetadata("oauth2-proxy/oauth2-proxy", "v7.3.0")
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]string{}, output2)
-}
-
-func TestDockerRetrieveDockerV2ManifestMetadata(t *testing.T) {
 	reg := DockerRegistry{
 		Url: "https://ghcr.io",
 	}
-	output, err := reg.RetrieveMetadata("airfocusio/git-ops-update-test", "docker-v2-manifest-v0.0.1")
+	output, err := reg.FetchVersions("airfocusio/git-ops-update-test")
 	assert.NoError(t, err)
-	assert.Contains(t, output, "org.opencontainers.image.version")
-	assert.Equal(t, "0.0.1", output["org.opencontainers.image.version"])
+	assert.Greater(t, len(output), 0)
+
+	assert.Contains(t, output, "docker-v2-manifest-v0.0.1")
+	assert.Contains(t, output, "docker-v2-manifest-v0.0.2")
+	assert.Contains(t, output, "docker-v2-manifest-list-v0.0.1")
+	assert.Contains(t, output, "docker-v2-manifest-list-v0.0.2")
+	assert.Contains(t, output, "oci-v1-manifest-v0.0.1")
+	assert.Contains(t, output, "oci-v1-manifest-v0.0.2")
+	assert.Contains(t, output, "oci-v1-image-index-v0.0.1")
+	assert.Contains(t, output, "oci-v1-image-index-v0.0.2")
 }
 
-func TestDockerRetrieveDockerV2ManifestListMetadata(t *testing.T) {
+func TestDockerRetrieveLabels(t *testing.T) {
 	reg := DockerRegistry{
 		Url: "https://ghcr.io",
 	}
-	output, err := reg.RetrieveMetadata("airfocusio/git-ops-update-test", "docker-v2-manifest-list-v0.0.1")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "org.opencontainers.image.version")
-	assert.Equal(t, "0.0.1", output["org.opencontainers.image.version"])
-}
 
-func TestDockerRetrieveOciV1ManifestMetadata(t *testing.T) {
-	reg := DockerRegistry{
-		Url: "https://ghcr.io",
-	}
-	output, err := reg.RetrieveMetadata("airfocusio/git-ops-update-test", "oci-v1-manifest-v0.0.1")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "org.opencontainers.image.version")
-	assert.Equal(t, "0.0.1", output["org.opencontainers.image.version"])
-}
+	t.Run("docker-v2-manifest", func(t *testing.T) {
+		output, err := reg.RetrieveLabels("airfocusio/git-ops-update-test", "docker-v2-manifest-v0.0.1")
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			"io.buildah.version":                "1.23.1",
+			"org.opencontainers.image.version":  "0.0.1",
+			"org.opencontainers.image.source":   "https://github.com/airfocusio/git-ops-update",
+			"org.opencontainers.image.revision": "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00",
+		}, output)
+	})
 
-func TestDockerRetrieveOciV1ImageIndexMetadata(t *testing.T) {
-	reg := DockerRegistry{
-		Url: "https://ghcr.io",
-	}
-	output, err := reg.RetrieveMetadata("airfocusio/git-ops-update-test", "oci-v1-image-index-v0.0.1")
-	assert.NoError(t, err)
-	assert.Contains(t, output, "org.opencontainers.image.version")
-	assert.Equal(t, "0.0.1", output["org.opencontainers.image.version"])
+	t.Run("oci-v1-manifest", func(t *testing.T) {
+		output, err := reg.RetrieveLabels("airfocusio/git-ops-update-test", "oci-v1-manifest-v0.0.1")
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			"io.buildah.version":                "1.23.1",
+			"org.opencontainers.image.version":  "0.0.1",
+			"org.opencontainers.image.source":   "https://github.com/airfocusio/git-ops-update",
+			"org.opencontainers.image.revision": "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00",
+		}, output)
+	})
+
+	t.Run("docker-v2-manifest-list", func(t *testing.T) {
+		output, err := reg.RetrieveLabels("airfocusio/git-ops-update-test", "docker-v2-manifest-list-v0.0.1")
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			"io.buildah.version":                "1.23.1",
+			"org.opencontainers.image.version":  "0.0.1",
+			"org.opencontainers.image.source":   "https://github.com/airfocusio/git-ops-update",
+			"org.opencontainers.image.revision": "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00",
+		}, output)
+	})
+
+	t.Run("oci-v1-image-index", func(t *testing.T) {
+		output, err := reg.RetrieveLabels("airfocusio/git-ops-update-test", "oci-v1-image-index-v0.0.1")
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			"io.buildah.version":                "1.23.1",
+			"org.opencontainers.image.version":  "0.0.1",
+			"org.opencontainers.image.source":   "https://github.com/airfocusio/git-ops-update",
+			"org.opencontainers.image.revision": "99a7aaa2eff5aff7c77d9caf0901454fedf6bf00",
+		}, output)
+	})
 }

--- a/internal/registry_github_tag.go
+++ b/internal/registry_github_tag.go
@@ -71,8 +71,3 @@ func (r GitHubTagRegistry) FetchVersions(repository string) ([]string, error) {
 
 	return result, nil
 }
-
-func (r GitHubTagRegistry) RetrieveMetadata(resource string, version string) (map[string]string, error) {
-	url := fmt.Sprintf("https://github.com/%s/releases/tag/%s", resource, version)
-	return map[string]string{"releaseUrl": url}, nil
-}

--- a/internal/registry_helm.go
+++ b/internal/registry_helm.go
@@ -69,7 +69,3 @@ func (r HelmRegistry) FetchVersions(chart string) ([]string, error) {
 
 	return result, nil
 }
-
-func (r HelmRegistry) RetrieveMetadata(resource string, version string) (map[string]string, error) {
-	return nil, nil
-}

--- a/internal/update.go
+++ b/internal/update.go
@@ -123,15 +123,9 @@ func DetectUpdates(dir string, config Config, cacheProvider CacheProvider) []Upd
 					errs = append(errs, fmt.Errorf("%s:%d: %w", fileRel, fileAnnotation.LineNum, err))
 					continue
 				}
-				metadata, err := (*annotation.Registry).RetrieveMetadata(annotation.ResourceName, *nextVersion)
-				if err != nil {
-					errs = append(errs, fmt.Errorf("%s:%d: %w", fileRel, fileAnnotation.LineNum, err))
-					continue
-				}
 				change := Change{
 					RegistryName: annotation.RegistryName,
 					ResourceName: annotation.ResourceName,
-					Metadata:     metadata,
 					OldVersion:   *currentVersion,
 					NewVersion:   *nextVersion,
 					File:         fileRel,
@@ -140,6 +134,7 @@ func DetectUpdates(dir string, config Config, cacheProvider CacheProvider) []Upd
 					OldValue:     currentValue,
 					NewValue:     *nextValue,
 				}
+				change.Comments = RenderChangeComments(dir, config, change)
 				result = append(result, UpdateVersionResult{Change: &change, Action: annotation.Action})
 			}
 		}
@@ -149,6 +144,21 @@ func DetectUpdates(dir string, config Config, cacheProvider CacheProvider) []Upd
 	}
 
 	return result
+}
+
+func RenderChangeComments(dir string, config Config, change Change) string {
+	augmenterMessages := []string{}
+	for _, a := range config.Augmenters {
+		augmenterMessage, err := a.RenderMessage(config, change)
+		if err == nil {
+			if augmenterMessage != "" {
+				augmenterMessages = append(augmenterMessages, augmenterMessage)
+			}
+		} else {
+			LogWarning("Unable to augment: %v", err)
+		}
+	}
+	return strings.Join(augmenterMessages, "\n\n")
 }
 
 type annotation struct {

--- a/internal/util.go
+++ b/internal/util.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 func fileList(dir string, includes []regexp.Regexp, excludes []regexp.Regexp) ([]string, error) {
@@ -61,4 +62,12 @@ func runCallbacks(callbacks []func() error) error {
 		}
 	}
 	return nil
+}
+
+func trimRightMultilineString(str string, cutset string) string {
+	lines := strings.Split(str, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], cutset)
+	}
+	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
So far one strategy, that looks for OCI labels `org.opencontainers.image.source` and `org.opencontainers.image.revision` and - if it finds something that looks like Github - generates a helpful message diffing the old and new version.