### PR TITLE
Add warning logs for GitHub compare API failures

### DIFF
--- a/internal/augmenter_github.go
+++ b/internal/augmenter_github.go
@@ -66,6 +66,11 @@ func (a GithubAugmenter) RenderMessage(config Config, change Change) (string, st
 			PerPage: 100,
 		})
 		defer res.Body.Close()
+		if err != nil {
+			LogWarning("Failed to compare commits for %s/%s: %v", owner, repo, err)
+		} else if comparison == nil {
+			LogWarning("Compare commits for %s/%s returned nil comparison", owner, repo)
+		}
 
 		result1 := GithubLink{
 			Title: "Compare",


### PR DESCRIPTION
Log warnings when the CompareCommits API call fails or returns nil, to help diagnose issues with PR/commit listing in release descriptions.

After migrating to a new GH enterprise org, the PRs generated by git-ops-update don't include "Commits" or "Pull request" sections in the description, but they do include a "Compare" link. I suspect this API call is where things are going wrong, so adding these logs will help debug it.